### PR TITLE
Made PubSubClient version fixed to 2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## [0.2.5] - 2020-06-19
+   
+### Added
+ 
+### Changed
+Made PubSubClient version fixed to 2.7 due to bug in WiFiClientSecure.cpp: https://github.com/knolleary/pubsubclient/issues/749
+That causes problem on PubSubClient version 2.8.
+
 ## [0.2.4] - 2020-03-30
    
 ### Added

--- a/library.json
+++ b/library.json
@@ -15,7 +15,7 @@
       "maintainer": true
     }
   ],
-  "version": "0.2.4",
+  "version": "0.2.5",
   "frameworks": "arduino",
   "platforms": "espressif32",
   "dependencies": [
@@ -33,7 +33,7 @@
     },
     {
       "name": "PubSubClient",
-      "version": "^2.7"
+      "version": "2.7"
     },
     {
       "name": "Bounce2",


### PR DESCRIPTION
Made PubSubClient version fixed to 2.7 due to bug in WiFiClientSecure.cpp: https://github.com/knolleary/pubsubclient/issues/749
That causes problem on PubSubClient version 2.8.